### PR TITLE
setup of the project

### DIFF
--- a/pintxarray/__init__.py
+++ b/pintxarray/__init__.py
@@ -1,1 +1,1 @@
-from .accessors import PintDataArrayAccessor, PintDatasetAccessor
+from .accessors import PintDataArrayAccessor, PintDatasetAccessor  # noqa

--- a/pintxarray/tests/test_accessors.py
+++ b/pintxarray/tests/test_accessors.py
@@ -7,11 +7,11 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from pint import UnitRegistry
-from pint.unit import Unit
-from pint.errors import UndefinedUnitError, DimensionalityError
+# from pint.unit import Unit
+from pint.errors import UndefinedUnitError  # , DimensionalityError
 
-from pintxarray.accessors import PintDataArrayAccessor, PintDatasetAccessor
-from .utils import extract_units, raises_regex
+# from pintxarray.accessors import PintDataArrayAccessor, PintDatasetAccessor
+from .utils import raises_regex  # extract_units
 
 
 # make sure scalars are converted to 0d arrays so quantities can
@@ -78,7 +78,7 @@ class TestQuantifyDataArray:
     def test_registry_kwargs(self, example_unitless_da):
         orig = example_unitless_da
         result = orig.pint.quantify(registry_kwargs={"auto_reduce_dimensions": True})
-        assert (result.data._REGISTRY.auto_reduce_dimensions) == True
+        assert result.data._REGISTRY.auto_reduce_dimensions is True
 
 
 class TestDequantifyDataArray:

--- a/pintxarray/tests/test_accessors.py
+++ b/pintxarray/tests/test_accessors.py
@@ -25,9 +25,10 @@ def example_unitless_da():
     array = np.linspace(0, 10, 20)
     x = np.arange(20)
     da = xr.DataArray(data=array, dims="x", coords={"x": x})
-    da.attrs['units'] = 'm'
-    da.coords['x'].attrs['units'] = 's'
+    da.attrs["units"] = "m"
+    da.coords["x"].attrs["units"] = "s"
     return da
+
 
 @pytest.fixture()
 def example_quantity_da():
@@ -39,30 +40,30 @@ def example_quantity_da():
 class TestQuantifyDataArray:
     def test_attach_units_from_str(self, example_unitless_da):
         orig = example_unitless_da
-        result = orig.pint.quantify('m')
+        result = orig.pint.quantify("m")
         assert_array_equal(result.data.magnitude, orig.data)
         # TODO better comparisons for when you can't access the unit_registry?
-        assert str(result.data.units) == 'meter'
+        assert str(result.data.units) == "meter"
 
     def test_attach_units_given_registry(self, example_unitless_da):
         orig = example_unitless_da
         ureg = UnitRegistry(force_ndarray=True)
-        result = orig.pint.quantify('m', unit_registry=ureg)
+        result = orig.pint.quantify("m", unit_registry=ureg)
         assert_array_equal(result.data.magnitude, orig.data)
-        assert result.data.units == ureg.Unit('m')
+        assert result.data.units == ureg.Unit("m")
 
     def test_attach_units_from_attrs(self, example_unitless_da):
         orig = example_unitless_da
         result = orig.pint.quantify()
         assert_array_equal(result.data.magnitude, orig.data)
-        assert str(result.data.units) == 'meter'
+        assert str(result.data.units) == "meter"
 
     def test_attach_units_given_unit_objs(self, example_unitless_da):
         orig = example_unitless_da
         ureg = UnitRegistry(force_ndarray=True)
-        result = orig.pint.quantify(ureg.Unit('m'), unit_registry=ureg)
+        result = orig.pint.quantify(ureg.Unit("m"), unit_registry=ureg)
         assert_array_equal(result.data.magnitude, orig.data)
-        assert result.data.units == ureg.Unit('m')
+        assert result.data.units == ureg.Unit("m")
 
     def test_error_when_already_units(self, example_quantity_da):
         da = example_quantity_da
@@ -72,20 +73,19 @@ class TestQuantifyDataArray:
     def test_error_on_nonsense_units(self, example_unitless_da):
         da = example_unitless_da
         with pytest.raises(UndefinedUnitError):
-            da.pint.quantify(units='aecjhbav')
+            da.pint.quantify(units="aecjhbav")
 
     def test_registry_kwargs(self, example_unitless_da):
         orig = example_unitless_da
-        result = orig.pint.quantify(registry_kwargs=
-                                    {'auto_reduce_dimensions': True})
-        assert(result.data._REGISTRY.auto_reduce_dimensions) == True
+        result = orig.pint.quantify(registry_kwargs={"auto_reduce_dimensions": True})
+        assert (result.data._REGISTRY.auto_reduce_dimensions) == True
 
 
 class TestDequantifyDataArray:
     def test_strip_units(self, example_quantity_da):
         result = example_quantity_da.pint.dequantify()
         assert isinstance(result.data, np.ndarray)
-        assert isinstance(result.coords['x'].data, np.ndarray)
+        assert isinstance(result.coords["x"].data, np.ndarray)
 
     def test_error_if_no_units(self, example_unitless_da):
         with raises_regex(ValueError, "does not have units"):
@@ -94,7 +94,7 @@ class TestDequantifyDataArray:
     def test_attrs_reinstated(self, example_quantity_da):
         da = example_quantity_da
         result = da.pint.dequantify()
-        assert result.attrs['units'] == 'meter'
+        assert result.attrs["units"] == "meter"
 
     def test_roundtrip_data(self, example_unitless_da):
         orig = example_unitless_da
@@ -108,21 +108,22 @@ def example_unitless_ds():
     users = np.linspace(0, 10, 20)
     funds = np.logspace(0, 10, 20)
     t = np.arange(20)
-    ds = xr.Dataset(data_vars={'users': (['t'], users),
-                               'funds': (['t'], funds)},
-                    coords={"t": t})
-    ds['users'].attrs['units'] = ''
-    ds['funds'].attrs['units'] = 'pound'
+    ds = xr.Dataset(
+        data_vars={"users": (["t"], users), "funds": (["t"], funds)}, coords={"t": t}
+    )
+    ds["users"].attrs["units"] = ""
+    ds["funds"].attrs["units"] = "pound"
     return ds
+
 
 @pytest.fixture()
 def example_quantity_ds():
     users = np.linspace(0, 10, 20) * unit_registry.dimensionless
     funds = np.logspace(0, 10, 20) * unit_registry.pound
     t = np.arange(20)
-    ds = xr.Dataset(data_vars={'users': (['t'], users),
-                               'funds': (['t'], funds)},
-                    coords={"t": t})
+    ds = xr.Dataset(
+        data_vars={"users": (["t"], users), "funds": (["t"], funds)}, coords={"t": t}
+    )
     return ds
 
 
@@ -148,35 +149,32 @@ class TestQuantifyDataSet:
     def test_attach_units_from_str(self, example_unitless_ds):
         orig = example_unitless_ds
         result = orig.pint.quantify()
-        assert_array_equal(result['users'].data.magnitude,
-                           orig['users'].data)
-        assert str(result['users'].data.units) == 'dimensionless'
+        assert_array_equal(result["users"].data.magnitude, orig["users"].data)
+        assert str(result["users"].data.units) == "dimensionless"
 
     def test_attach_units_given_registry(self, example_unitless_ds):
         orig = example_unitless_ds
-        orig['users'].attrs.clear()
-        result = orig.pint.quantify({'users': 'dimensionless'},
-                                    unit_registry=unit_registry)
-        assert_array_equal(result['users'].data.magnitude,
-                           orig['users'].data)
-        assert str(result['users'].data.units) == 'dimensionless'
+        orig["users"].attrs.clear()
+        result = orig.pint.quantify(
+            {"users": "dimensionless"}, unit_registry=unit_registry
+        )
+        assert_array_equal(result["users"].data.magnitude, orig["users"].data)
+        assert str(result["users"].data.units) == "dimensionless"
 
     def test_attach_units_from_attrs(self, example_unitless_ds):
         orig = example_unitless_ds
-        orig['users'].attrs.clear()
-        result = orig.pint.quantify({'users': 'dimensionless'})
-        assert_array_equal(result['users'].data.magnitude,
-                           orig['users'].data)
-        assert str(result['users'].data.units) == 'dimensionless'
+        orig["users"].attrs.clear()
+        result = orig.pint.quantify({"users": "dimensionless"})
+        assert_array_equal(result["users"].data.magnitude, orig["users"].data)
+        assert str(result["users"].data.units) == "dimensionless"
 
     def test_attach_units_given_unit_objs(self, example_unitless_ds):
         orig = example_unitless_ds
-        orig['users'].attrs.clear()
-        dimensionless = unit_registry.Unit('dimensionless')
-        result = orig.pint.quantify({'users': dimensionless})
-        assert_array_equal(result['users'].data.magnitude,
-                           orig['users'].data)
-        assert str(result['users'].data.units) == 'dimensionless'
+        orig["users"].attrs.clear()
+        dimensionless = unit_registry.Unit("dimensionless")
+        result = orig.pint.quantify({"users": dimensionless})
+        assert_array_equal(result["users"].data.magnitude, orig["users"].data)
+        assert str(result["users"].data.units) == "dimensionless"
 
     def test_error_when_already_units(self, example_quantity_ds):
         with raises_regex(ValueError, "already has units"):
@@ -185,7 +183,7 @@ class TestQuantifyDataSet:
     def test_error_on_nonsense_units(self, example_unitless_ds):
         ds = example_unitless_ds
         with pytest.raises(UndefinedUnitError):
-            ds.pint.quantify(units={'users': 'aecjhbav'})
+            ds.pint.quantify(units={"users": "aecjhbav"})
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/pintxarray/tests/test_accessors.py
+++ b/pintxarray/tests/test_accessors.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from pint import UnitRegistry
+
 # from pint.unit import Unit
 from pint.errors import UndefinedUnitError  # , DimensionalityError
 

--- a/pintxarray/tests/utils.py
+++ b/pintxarray/tests/utils.py
@@ -19,6 +19,7 @@ def raises_regex(error, pattern):
             f"exception {excinfo.value!r} did not match pattern {pattern!r}"
         )
 
+
 def array_extract_units(obj):
     if isinstance(obj, (xr.Variable, xr.DataArray, xr.Dataset)):
         obj = obj.data
@@ -27,6 +28,7 @@ def array_extract_units(obj):
         return obj.units
     except AttributeError:
         return None
+
 
 def extract_units(obj):
     if isinstance(obj, xr.Dataset):
@@ -58,9 +60,11 @@ def extract_units(obj):
 
     return units
 
+
 def assert_units_equal(a, b):
     __tracebackhide__ = True
     assert extract_units(a) == extract_units(b)
+
 
 def assert_equal_with_units(a, b):
     # works like xr.testing.assert_equal, but also explicitly checks units

--- a/pintxarray/tests/utils.py
+++ b/pintxarray/tests/utils.py
@@ -66,35 +66,35 @@ def assert_units_equal(a, b):
     assert extract_units(a) == extract_units(b)
 
 
-def assert_equal_with_units(a, b):
-    # works like xr.testing.assert_equal, but also explicitly checks units
-    # so, it is more like assert_identical
-    __tracebackhide__ = True
-
-    if isinstance(a, xr.Dataset) or isinstance(b, xr.Dataset):
-        a_units = extract_units(a)
-        b_units = extract_units(b)
-
-        a_without_units = strip_units(a)
-        b_without_units = strip_units(b)
-
-        assert a_without_units.equals(b_without_units), formatting.diff_dataset_repr(
-            a, b, "equals"
-        )
-        assert a_units == b_units
-    else:
-        a = a if not isinstance(a, (xr.DataArray, xr.Variable)) else a.data
-        b = b if not isinstance(b, (xr.DataArray, xr.Variable)) else b.data
-
-        assert type(a) == type(b) or (
-            isinstance(a, Quantity) and isinstance(b, Quantity)
-        )
-
-        # workaround until pint implements allclose in __array_function__
-        if isinstance(a, Quantity) or isinstance(b, Quantity):
-            assert (
-                hasattr(a, "magnitude") and hasattr(b, "magnitude")
-            ) and np.allclose(a.magnitude, b.magnitude, equal_nan=True)
-            assert (hasattr(a, "units") and hasattr(b, "units")) and a.units == b.units
-        else:
-            assert np.allclose(a, b, equal_nan=True)
+# def assert_equal_with_units(a, b):
+#     # works like xr.testing.assert_equal, but also explicitly checks units
+#     # so, it is more like assert_identical
+#     __tracebackhide__ = True
+#
+#     if isinstance(a, xr.Dataset) or isinstance(b, xr.Dataset):
+#         a_units = extract_units(a)
+#         b_units = extract_units(b)
+#
+#         a_without_units = strip_units(a)
+#         b_without_units = strip_units(b)
+#
+#         assert a_without_units.equals(b_without_units), formatting.diff_dataset_repr(
+#             a, b, "equals"
+#         )
+#         assert a_units == b_units
+#     else:
+#         a = a if not isinstance(a, (xr.DataArray, xr.Variable)) else a.data
+#         b = b if not isinstance(b, (xr.DataArray, xr.Variable)) else b.data
+#
+#         assert type(a) == type(b) or (
+#             isinstance(a, Quantity) and isinstance(b, Quantity)
+#         )
+#
+#         # workaround until pint implements allclose in __array_function__
+#         if isinstance(a, Quantity) or isinstance(b, Quantity):
+#             assert (
+#                 hasattr(a, "magnitude") and hasattr(b, "magnitude")
+#             ) and np.allclose(a.magnitude, b.magnitude, equal_nan=True)
+#             assert (hasattr(a, "units") and hasattr(b, "units")) and a.units == b.units
+#         else:
+#             assert np.allclose(a, b, equal_nan=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 41", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/hgrecco/pint.git@master#egg=pint-master
-numpy==1.17.1
-xarray==0.15.1
+numpy>=1.17.1
+xarray>=0.15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,11 @@ version = 0.0.1
 author = Tom Nicholas
 author_email = tomnicholas1@googlemail.com
 description = Physical units interface to xarray using Pint
-packages = find:
 url = https://github.com/TomNicholas/pint-xarray
 
 [options]
+packages = find:
+python_requires = >=3.6
 install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+    name = pint-xarray
+    version = 0.0.1
+    author = Tom Nicholas
+    author_email = tomnicholas1@googlemail.com
+    description = Physical units interface to xarray using Pint
+    packages = find:
+    url = https://github.com/TomNicholas/pint-xarray
+    install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,7 @@ author_email = tomnicholas1@googlemail.com
 description = Physical units interface to xarray using Pint
 packages = find:
 url = https://github.com/TomNicholas/pint-xarray
+
+[options]
 install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
-    name = pint-xarray
-    version = 0.0.1
-    author = Tom Nicholas
-    author_email = tomnicholas1@googlemail.com
-    description = Physical units interface to xarray using Pint
-    packages = find:
-    url = https://github.com/TomNicholas/pint-xarray
-    install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
+name = pint-xarray
+version = 0.0.1
+author = Tom Nicholas
+author_email = tomnicholas1@googlemail.com
+description = Physical units interface to xarray using Pint
+packages = find:
+url = https://github.com/TomNicholas/pint-xarray
+install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,16 @@ url = https://github.com/TomNicholas/pint-xarray
 [options]
 install_requires = numpy>=1.17.1; xarray>=0.15.1; pint>=0.12
 
+[flake8]
+ignore =
+    # whitespace before ':' - doesn't work well with black
+    E203
+    E402
+    # line too long - let black worry about that
+    E501
+    # do not assign a lambda expression, use a def
+    E731
+    # line break before binary operator
+    W503
+exclude=
+    .eggs

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name='pint-xarray',
-    version='0.0.1',
-    author='Tom Nicholas',
-    author_email='tomnicholas1@googlemail.com',
-    description='Physical units interface to xarray using Pint',
-    packages=find_packages(),
-    url='https://github.com/TomNicholas/pint-xarray',
-    install_requires=['numpy >= 1.17.1',
-                      'xarray >= 0.15.1',
-                      'pint >= 0.12'],
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
This adds a `pyproject.toml` (see [What the heck is pyproject.toml](https://snarky.ca/what-the-heck-is-pyproject-toml/) for its purpose) and moves the metadata from `setup.py` to `setup.cfg`. With that, the only reason we still need `setup.py` is for editable installs (`python -m pip install -e .`).

For versions, both `pint` and `xarray` rely on `setuptools_scm`, which uses the repository's tags to provide a version. Should we use it, too?