### PR TITLE
initial documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/generated/
 
 # PyBuilder
 target/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,7 +13,6 @@ Dataset
 
    Dataset.pint.quantify
    Dataset.pint.dequantify
-   Dataset.pint.to
    Dataset.pint.to_base_units
    Dataset.pint.to_system
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,38 @@
+.. currentmodule:: xarray
+
+API reference
+=============
+This page contains a auto-generated summary of ``pint-xarray``'s API.
+
+
+Dataset
+-------
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_method.rst
+
+   Dataset.pint.quantify
+   Dataset.pint.dequantify
+   Dataset.pint.to
+   Dataset.pint.to_base_units
+   Dataset.pint.to_system
+
+DataArray
+---------
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_property.rst
+
+   DataArray.pint.magnitude
+   DataArray.pint.units
+   DataArray.pint.dimensionality
+   DataArray.pint.registry
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_method.rst
+
+   DataArray.pint.quantify
+   DataArray.pint.dequantify
+   DataArray.pint.to
+   DataArray.pint.to_base_units

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,12 +44,6 @@ extensions = [
     "sphinx_autosummary_accessors",
 ]
 
-autosummary_generate = True
-autodoc_typehints = "none"
-
-napoleon_use_param = True
-napoleon_use_rtype = True
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 
@@ -73,6 +67,12 @@ html_theme = "sphinx_rtd_theme"
 
 
 # -- Extension configuration -------------------------------------------------
+
+autosummary_generate = True
+autodoc_typehints = "none"
+
+napoleon_use_param = True
+napoleon_use_rtype = True
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,80 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+# -- Imports -----------------------------------------------------------------
+
+import datetime as dt
+
+import sphinx_autosummary_accessors
+
+# need to import so accessors get registered
+import pintxarray  # noqa: F401
+
+# -- Project information -----------------------------------------------------
+
+year = dt.datetime.now().year
+project = "pint-xarray"
+author = f"{project} developers"
+copyright = f"{year}, {author}"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx_autosummary_accessors",
+]
+
+autosummary_generate = True
+autodoc_typehints = "none"
+
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {"https://docs.python.org/3/": None}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. accessors documentation master file, created by
+   sphinx-quickstart on Thu Jul  2 01:49:50 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to accessors's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+pint>=0.13
+xarray>=0.15.1
+sphinx>=3.0
+sphinx_rtd_theme
+nbsphinx
+git+https://github.com/keewis/sphinx-autosummary-accessors

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  image: latest
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,12 @@ ignore =
     W503
 exclude=
     .eggs
+
+[isort]
+default_section = THIRDPARTY
+known_first_party = pintxarray
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88


### PR DESCRIPTION
Initial skeleton of the documentation. I'm using my (unreleased) [sphinx-autosummary-accessors](https://github.com/keewis/sphinx-autosummary-accessors) project to format the accessor pages properly, which seems to work just fine.